### PR TITLE
Changed references to credentials

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+{"token" : "Discord API Token", "botOwners" : ["host ID"], "mongoConnectionURL" : "mongoDB URI"}

--- a/credentials_example.json
+++ b/credentials_example.json
@@ -1,5 +1,0 @@
-{
-  "token"  : "BOT'S TOKEN https://discordapp.com/developers/applications/me",
-  "botOwners" : ["YOUR ID"],
-  "mongoConnectionURL" : "CONNECTION URL TO MONGODB"
-}

--- a/src/preconditions/command/BotOwner.js
+++ b/src/preconditions/command/BotOwner.js
@@ -1,5 +1,6 @@
 const { Precondition, PreconditionResult } = require('patron.js');
-const credentials = require('../../../credentials.json');
+const envfile = require('fs').readFileSync('../../.env','UTF8');
+const credentials = eval(envfile.splice(1,envfile.indexOf('\n')));
 
 class BotOwner extends Precondition {
   constructor() {

--- a/src/structures/Client.js
+++ b/src/structures/Client.js
@@ -1,7 +1,8 @@
 const { Client: DiscordJSClient } = require('discord.js');
 const Constants = require('../utility/Constants.js');
 const Database = require('../database/Database.js');
-const credentials = require('../../credentials.json');
+const envfile = require('fs').readFileSync('../../.env','UTF8');
+const credentials = eval(envfile.splice(1,envfile.indexOf('\n')));
 
 class Client extends DiscordJSClient {
   constructor(config) {


### PR DESCRIPTION
Since credentials must be stored in `.env` for glitch to hide them, I have modified the files using them to read from this. Credentials should be stored as a comment on the first line of `.env`, for example: `# {"token":"[Discord API token]","botOwners":["host ID"],"mongoConnectionURL":"[mongoDB URI]"}`